### PR TITLE
LADWP Aqueduct sensor readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Maintained for use by local Code for America Brigade, Code for LA. [Meetup](http
 + [Experience LA Calendar RSS Feed](http://www.experiencela.com/calendar/rss)
 + [Google Civic Information API](https://developers.google.com/civic-information/)
 + [DataCatalogs.org](http://datacatalogs.org/) Searchable list of data catalogs from around the world
++ [api.thirsty.la](http://api.thirsty.la/) scraped and compiled from some realtime LADWP water sensors in the Owens Valley, including the Los Angeles Aqueduct.
 
 ##Potential
 


### PR DESCRIPTION
I've been scraping and accumulating sensor readings from a [perhaps abandoned website](http://wsoweb.ladwp.com/Aqueduct/realtime/) which seems to have come out of one of the LADWP/Owens Valley settlements.

It originally came out of my frustrating inability to find any sort of real time data being published by LADWP, and several failed attempts at asking for consumption data via email. 

You can read more at http://api.thirsty.la/

I'm not sure if this is in line with your list. What do you think?
