### PR TITLE
Fixed typographical error, changed adminstration to administration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Maintained for use by local Code for America Brigade, Hack for LA. [Website](htt
 + [Neighborland API](https://neighborland.com/docs)
 + [U.S. Census Tiger Shapefiles](http://forever.codeforamerica.org/Census-API/shutdown-2013.html) a list of where to find shp files not acccessbile through normal routes due to the shutdown
 + [City SDK from the Census Bureau](http://uscensusbureau.github.io/citysdk/)
-+ [National Highway Traffic Safety Adminstration Fatality Analysis Reporting System and Data](http://www.nhtsa.gov/FARS) raw data available
++ [National Highway Traffic Safety Administration Fatality Analysis Reporting System and Data](http://www.nhtsa.gov/FARS) raw data available
 + [National Endowment for the Arts - Survey of Public Participation in the Arts](http://arts.gov/publications/additional-materials-related-to-2012-sppa) raw data available in multiple formats
 + [Experience LA Calendar RSS Feed](http://www.experiencela.com/calendar/rss)
 + [Google Civic Information API](https://developers.google.com/civic-information/)


### PR DESCRIPTION
@vykster, I've corrected a typographical error in the documentation of the [los-angeles-data-sources](https://github.com/vykster/los-angeles-data-sources) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
